### PR TITLE
Fix for ball not changing color when slider is changing color

### DIFF
--- a/MaterialDesign/src/com/gc/materialdesign/views/Slider.java
+++ b/MaterialDesign/src/com/gc/materialdesign/views/Slider.java
@@ -173,6 +173,7 @@ public class Slider extends CustomView {
     @Override
     public void setBackgroundColor(int color) {
         backgroundColor = color;
+        ball.changeBackground();
         if (isEnabled())
             beforeBackground = backgroundColor;
     }


### PR DESCRIPTION
When dynamically changing color of Slider via setBackgroundColor(int), slider changes color properly apart from ball. Ball changes color only after it is touched (onTouchEvent) or slider value is changed (setValue). This fixes issue and colors whole slider at the same time.