### PR TITLE
Fix wrong contstant in AutoHideButtonFloat

### DIFF
--- a/MaterialDesign/src/com/gc/materialdesign/views/AutoHideButtonFloat.java
+++ b/MaterialDesign/src/com/gc/materialdesign/views/AutoHideButtonFloat.java
@@ -1,5 +1,6 @@
 package com.gc.materialdesign.views;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
@@ -36,7 +37,7 @@ public class AutoHideButtonFloat extends ButtonFloat implements AbsListView.OnSc
     @Override
     public void onScrollStateChanged(AbsListView absListView, int scrollState) {
         switch (scrollState) {
-            case AbsListView.SCROLL_AXIS_NONE:
+            case AbsListView.OnScrollListener.SCROLL_STATE_IDLE:
                 floatHiding = false;
                 floatShowing = false;
                 ViewPropertyAnimator.animate(view).translationY(0).setDuration(300);

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
 include ':MaterialDesign'
+include ':MaterialDesignDemo'


### PR DESCRIPTION
Fix `AutoHideButtonFloat.onScrollStateChanged`

Callback was using [`View.SCROLL_AXIS_NONE`](http://developer.android.com/reference/android/view/View.html#SCROLL_AXIS_NONE) which is API 21 and up only. It should have used [`AbsListView.OnScrollListener.SCROLL_STATE_IDLE`](http://developer.android.com/reference/android/widget/AbsListView.OnScrollListener.html#SCROLL_STATE_IDLE)

Fixes #300
