### PR TITLE
Fixed NullPointerException when using Slider on Android 2.3.3

### DIFF
--- a/MaterialDesignLibrary/MaterialDesign/src/main/java/com/gc/materialdesign/views/Slider.java
+++ b/MaterialDesignLibrary/MaterialDesign/src/main/java/com/gc/materialdesign/views/Slider.java
@@ -94,7 +94,9 @@ public class Slider extends CustomView {
 
     @Override
     public void invalidate() {
-        ball.invalidate();
+        if (ball != null) {
+            ball.invalidate();
+        }
         super.invalidate();
     }
 


### PR DESCRIPTION
On a 2.3.3 device an application throws a NullPointerException. The problem does not present itself on a 4.3 test device. Wrapping the `ball.invalidate()` call in a null check seems to resolve it.

Original trace below:
`E/AndroidRuntime( 3827): android.view.InflateException: Binary XML file line #9: Error inflating class com.gc.materialdesign.views.Slider
E/AndroidRuntime( 3827): 	at android.view.LayoutInflater.createView(LayoutInflater.java:518)
E/AndroidRuntime( 3827): 	at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:570)
E/AndroidRuntime( 3827): 	at android.view.LayoutInflater.rInflate(LayoutInflater.java:623)
E/AndroidRuntime( 3827): 	at android.view.LayoutInflater.inflate(LayoutInflater.java:408)
E/AndroidRuntime( 3827): 	at android.view.LayoutInflater.inflate(LayoutInflater.java:320)
E/AndroidRuntime( 3827): 	at android.view.ViewStub.inflate(ViewStub.java:232)
E/AndroidRuntime( 3827): 	at android.view.ViewStub.setVisibility(ViewStub.java:213)
E/AndroidRuntime( 3827): 	
....
E/AndroidRuntime( 3827): 	at android.os.Handler.dispatchMessage(Handler.java:99)
E/AndroidRuntime( 3827): 	at android.os.Looper.loop(Looper.java:130)
E/AndroidRuntime( 3827): 	at android.app.ActivityThread.main(ActivityThread.java:3687)
E/AndroidRuntime( 3827): 	at java.lang.reflect.Method.invokeNative(Native Method)
E/AndroidRuntime( 3827): 	at java.lang.reflect.Method.invoke(Method.java:507)
E/AndroidRuntime( 3827): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:867)
E/AndroidRuntime( 3827): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:625)
E/AndroidRuntime( 3827): 	at dalvik.system.NativeStart.main(Native Method)
E/AndroidRuntime( 3827): Caused by: java.lang.reflect.InvocationTargetException
E/AndroidRuntime( 3827): 	at java.lang.reflect.Constructor.constructNative(Native Method)
E/AndroidRuntime( 3827): 	at java.lang.reflect.Constructor.newInstance(Constructor.java:415)
E/AndroidRuntime( 3827): 	at android.view.LayoutInflater.createView(LayoutInflater.java:505)
E/AndroidRuntime( 3827): 	... 30 more
E/AndroidRuntime( 3827): Caused by: java.lang.NullPointerException
E/AndroidRuntime( 3827): 	at com.gc.materialdesign.views.Slider.invalidate(Slider.java:97)
E/AndroidRuntime( 3827): 	at android.view.View.setBackgroundDrawable(View.java:7626)
E/AndroidRuntime( 3827): 	at android.view.View.<init>(View.java:2160)
E/AndroidRuntime( 3827): 	at android.view.View.<init>(View.java:1899)
E/AndroidRuntime( 3827): 	at android.view.ViewGroup.<init>(ViewGroup.java:286)
E/AndroidRuntime( 3827): 	at android.widget.RelativeLayout.<init>(RelativeLayout.java:173)
E/AndroidRuntime( 3827): 	at com.gc.materialdesign.views.CustomView.<init>(CustomView.java:22)
E/AndroidRuntime( 3827): 	at com.gc.materialdesign.views.Slider.<init>(Slider.java:41)
E/AndroidRuntime( 3827): 	... 33 more`