### PR TITLE
[FIX] NullPointerException for API 10

### DIFF
--- a/MaterialDesignLibrary/MaterialDesign/src/main/java/com/gc/materialdesign/views/CheckBox.java
+++ b/MaterialDesignLibrary/MaterialDesign/src/main/java/com/gc/materialdesign/views/CheckBox.java
@@ -106,7 +106,8 @@ public class CheckBox extends CustomView {
 
 	@Override
 	public void invalidate() {
-		checkView.invalidate();
+		if(null != checkView)
+			checkView.invalidate();
 		super.invalidate();
 	}
 


### PR DESCRIPTION
Target: API level 10
Device: Emulator

when invalidate is called NullPointerException is thrown (checkView is null already).