### PR TITLE
fix ButtonFloat setDrawableIcon method invalid

### DIFF
--- a/MaterialDesignLibrary/MaterialDesign/src/main/java/com/gc/materialdesign/views/ButtonFloat.java
+++ b/MaterialDesignLibrary/MaterialDesign/src/main/java/com/gc/materialdesign/views/ButtonFloat.java
@@ -52,7 +52,11 @@ public class ButtonFloat extends Button{
 		icon.setAdjustViewBounds(true);
 		icon.setScaleType(ScaleType.CENTER_CROP);
 		if(drawableIcon != null) {
-			icon.setImageDrawable(drawableIcon);
+			try {
+				icon.setBackground(drawableIcon);
+			} catch (NoSuchMethodError e) {
+				icon.setBackgroundDrawable(drawableIcon);
+			}
 		}
 		LayoutParams params = new LayoutParams(Utils.dpToPx(sizeIcon, getResources()),Utils.dpToPx(sizeIcon, getResources()));
 		params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);


### PR DESCRIPTION
In the constructed function of  class `ButtonFloat`, it used **`setImageDrawable()`** to set the drawable.

But in the class method setDrawableIcon, it used **`setBackground()`** to set the  drawable.

In runtime, u call **`setBackground()`** and find the old drawable set in constructed function(xml layout file) will cover the new drawable, so we'd better make it consistence.