### PR TITLE
override setText() setTextColor() getTextView() getText() method in ButtonRectangle

### DIFF
--- a/MaterialDesignLibrary/MaterialDesign/src/main/java/com/gc/materialdesign/views/ButtonRectangle.java
+++ b/MaterialDesignLibrary/MaterialDesign/src/main/java/com/gc/materialdesign/views/ButtonRectangle.java
@@ -146,5 +146,20 @@ public class ButtonRectangle extends Button {
 			invalidate();
 		}
 	}
-	
+
+    public void setText(String text) {
+        textButton.setText(text);
+    }
+
+    public void setTextColor(int color) {
+        textButton.setTextColor(color);
+    }
+
+    public TextView getTextView() {
+        return textButton;
+    }
+
+    public String getText() {
+        return textButton.getText().toString();
+    }
 }


### PR DESCRIPTION
when I call buttonRectangle.setText() in java code,the app crashed,the textbutton i set is the private member of Button class,and it equals null.so override setText() setTextColor() getTextView() getText() method in ButtonRectangle will resolve the problem