### PR TITLE
Udpating README to reflect CheckBox's android:text tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Some components have custom attributes, if you want use them, you must add this 
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="#1E88E5"
+                android:text="CheckBox"
                 materialdesign:check="true" />
 ```
 


### PR DESCRIPTION
Noticed README section for CheckBox doesn't indicate android:text as one of the tags.