### PR TITLE
Replaced "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.github.navasmdc:MaterialDesign:1.5@aar'
+    implementation 'com.github.navasmdc:MaterialDesign:1.5@aar'
 }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.